### PR TITLE
Issue 47 google analytics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 jekyll:
   image: jekyll/jekyll:3.8.6
-  command: jekyll serve --drafts --livereload
+  command: jekyll serve --drafts --livereload --incremental
   ports:
     - 4000:4000
     - 35729:35729

--- a/source/_includes/google-analytics.html
+++ b/source/_includes/google-analytics.html
@@ -1,12 +1,6 @@
-<script>
-if(!(window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1")) {
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', '{{ site.google_analytics }}', 'auto');
-  ga('send', 'pageview');
-}
+{% if jekyll.environment != "development" %}
+<!-- Google Tag Manager -->
+<script>if(!(window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1")) { (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-5RFHNC');}
 </script>
-  
+<!-- End Google Tag Manager -->
+{% endif; %}

--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -22,6 +22,8 @@
     <script src="/assets/js/back-to-top.js"></script>
     <script src="/assets/js/toggle.js"></script>
 
+    {%- include google-analytics.html -%}
+
 </body>
 
 </html>


### PR DESCRIPTION
This PR adds Google Analytics to the site and adds the `--incremental` flag to the Jekyll command run by docker-compose. Resolves issue #47.

- GA is only added during production builds, using Liquid logic and the `jekyll.environment` variable.
- `--incremental` tries to force Jekyll to only re-build what has changed since the last save. It can speed up development builds.